### PR TITLE
Max width on text-heavy blocs, centered breadcrumb

### DIFF
--- a/2018/code-conduite.html
+++ b/2018/code-conduite.html
@@ -79,7 +79,7 @@
   <div class="container">
     <div class="section">
       <div class="row">
-        <div class="row">
+        <div class="row text-container">
           <div class="small-12 large-9 small-centered columns">
             <h2>Introduction</h2>
             <p>

--- a/2018/css/style.css
+++ b/2018/css/style.css
@@ -4779,6 +4779,7 @@ nav {
     line-height: 56px; }
   nav .nav-wrapper {
     position: relative;
+    text-align: center;
     height: 100%; }
   @media only screen and (min-width: 993px) {
     nav a.button-collapse {
@@ -9060,3 +9061,9 @@ nav ul a {
   bottom: 0px;
   left: -100%;
   z-index: 1000; }
+
+.text-container {
+  max-width: 700px;
+  margin-left: auto !important;
+  margin-right: auto !important;
+}

--- a/2018/index.html
+++ b/2018/index.html
@@ -164,7 +164,7 @@
   <a id="cfp"></a>
   <div class="container">
     <div class="section">
-      <div class="row center">
+      <div class="row center text-container">
         <div class="col s12">
           <h3>Appel à présentations</h3>
           <p>Venez faire une présentation !</p>
@@ -198,7 +198,7 @@
 
   <div class="container">
     <div class="section">
-      <div class="row">
+      <div class="row text-container">
         <div class="col s12 center">
           <h4> ❤️Sponsors ❤️</h4>
           <p class="left-align light">

--- a/2018/mentions-legales.html
+++ b/2018/mentions-legales.html
@@ -79,7 +79,7 @@
   <div class="container">
     <div class="section">
       <div class="row">
-        <div class="row">
+        <div class="row text-container">
           <div class="small-12 large-9 small-centered columns">
 
             <p>

--- a/2018/programme.html
+++ b/2018/programme.html
@@ -79,7 +79,7 @@
   <div class="container">
     <div class="section">
       <div class="row">
-        <div class="row">
+        <div class="row text-container">
           <div class="small-12 large-9 small-centered columns">
             <h2>Vendredi</h2>
             <p>


### PR DESCRIPTION
Une toute petite PR pour améliorer la lisibilité du site sur les écrans larges. Le fait d'avoir des lignes moins longues réduit la fatigue visuelle lors de la lecture.

# Avant

Code de conduite:

![image](https://user-images.githubusercontent.com/1970915/38135040-442c98a4-3416-11e8-9e10-7c2183ea4a4e.png)

Programme:

![image](https://user-images.githubusercontent.com/1970915/38135050-591acfd8-3416-11e8-9708-13c705fe9536.png)

Bloc sponsor sur l'accueil:

![image](https://user-images.githubusercontent.com/1970915/38135128-b8f2a750-3416-11e8-9513-78b47bb96ee7.png)

# Après

Note: les images/icônes sont cassés en local j'ai l'impression, donc il faut faire abstraction ;)

Code de conduite:

![image](https://user-images.githubusercontent.com/1970915/38135188-15f6f8d4-3417-11e8-8982-794c7c518c90.png)

Programme:

![image](https://user-images.githubusercontent.com/1970915/38135181-0be999e6-3417-11e8-9004-abd5ad74f23a.png)

Bloc sponsor sur l'accueil:

![image](https://user-images.githubusercontent.com/1970915/38135169-005d1a1c-3417-11e8-80a4-c2e456fd5f84.png)
