### PR TITLE
Lower leaflet controls z-index

### DIFF
--- a/2018/css/style.css
+++ b/2018/css/style.css
@@ -12057,6 +12057,11 @@ nav ul a {
 [id="map_djangocong"] {
   height: 400px; }
 
+.leaflet-top, .leaflet-bottom {
+  /* override default (1000) since the navbar is at 997 */
+  z-index: 996;
+}
+
 .hidden-g {
   color: #ffffff20;
   font-size: 60%; }

--- a/2018/index.html
+++ b/2018/index.html
@@ -9,7 +9,6 @@
   <link rel="apple-touch-icon" href="apple_touch_icon.png" />
   <link href="//fonts.googleapis.com/icon?family=Material+Icons|Montserrat" rel="stylesheet" />
   <link href="//cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.5.5/slick.min.css" rel="stylesheet" />
-  <link type="text/css" rel="stylesheet" href="css/style.css" media="screen"/>
   <!-- Ce site est équipé de la dernière génération de Konami-code -->
 
   <!-- Leaflet -->
@@ -19,6 +18,8 @@
   <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js"
     integrity="sha512-/Nsx9X4HebavoBvEBuyp3I7od5tA0UzAxs+j83KgC8PU0kgB4XiK4Lfe4y4cgBtaRJQEIFCW+oC506aPT2L1zw=="
     crossorigin=""></script>
+
+  <link type="text/css" rel="stylesheet" href="css/style.css" media="screen"/>
 
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-114866419-1"></script>
   <script>

--- a/2018/sass/style.scss
+++ b/2018/sass/style.scss
@@ -167,6 +167,11 @@ nav {
   height: 400px;
 }
 
+.leaflet-top, .leaflet-bottom {
+  /* override default (1000) since the navbar is at 997 */
+  z-index: 996;
+}
+
 .hidden-g {
   color: #ffffff20;
   font-size: 60%;


### PR DESCRIPTION
Leaflet controls were shown above the navbar:

![screenshot-2018-5-8 djangocong 2018 - lille](https://user-images.githubusercontent.com/1469823/39784384-7b3706ec-5318-11e8-888b-651741ec9d7e.png)

I had to move the style.css so it gets higher priority than the leaflet css.

I didn't manage to compile the .sass myself (missing the fontawesome module in nodes_modules) so I just copy pasted the change to both files.